### PR TITLE
Move base path into email template 

### DIFF
--- a/src/main/java/com/redhat/management/approval/ApprovalApiHelper.java
+++ b/src/main/java/com/redhat/management/approval/ApprovalApiHelper.java
@@ -69,7 +69,9 @@ public class ApprovalApiHelper implements java.io.Serializable {
     // Used in bpmn
     public static String getRequestUrl(Request request) {
         String apiUrl = System.getenv("APPROVAL_API_URL");
-        return apiUrl + "/api/approval/v1.0/requests/"+ request.getId() +"/actions";
+        String basePath = System.getenv("APPROVAL_API_BASE_PATH");
+
+        return apiUrl + basePath +"/requests/"+ request.getId() +"/actions";
     }
 
     public static boolean isRequestSkippable(String action) {

--- a/src/main/java/com/redhat/management/approval/ApprovalApiHelper.java
+++ b/src/main/java/com/redhat/management/approval/ApprovalApiHelper.java
@@ -25,6 +25,8 @@ public class ApprovalApiHelper implements java.io.Serializable {
     public static final int PARSE_EMAIL_ERROR = 3;
     public static final int PARSE_HEADER_URL_ERROR = 4;
 
+    public static final String APPROVAL_API_BASE_PATH = "/api/approval/v1.1";
+
     public static String formatDate(String pattern, String timeStr) {
         DateFormat df = new SimpleDateFormat(pattern);
         return df.format(getDate(timeStr));
@@ -63,15 +65,14 @@ public class ApprovalApiHelper implements java.io.Serializable {
     }
     
     public static String getRequestErrorContent(String reason) {
-        return "{\"operation\": \"error\", \"processed_by\": \"system\", \"comments\": \"" + reason + "\"}";
+        return String.format("{\"operation\": \"error\", \"processed_by\": \"system\", \"comments\": \"%s\"}", reason);
     }
 
     // Used in bpmn
     public static String getRequestUrl(Request request) {
         String apiUrl = System.getenv("APPROVAL_API_URL");
-        String basePath = System.getenv("APPROVAL_API_BASE_PATH");
 
-        return apiUrl + basePath +"/requests/"+ request.getId() +"/actions";
+        return String.format("%s%s/requests/%s/actions", apiUrl, APPROVAL_API_BASE_PATH, request.getId());
     }
 
     public static boolean isRequestSkippable(String action) {

--- a/src/main/java/com/redhat/management/approval/Email.java
+++ b/src/main/java/com/redhat/management/approval/Email.java
@@ -24,7 +24,7 @@ public class Email implements Serializable {
     }
 
     public void setSubject(String requestID, String requestName) {
-        this.subject = "Catalog:Approval Order " + requestID + ": " + requestName;
+        this.subject = String.format("Catalog:Approval Order %s: %s", requestID, requestName);
     }
 
     public String getBodyType() {

--- a/src/main/java/com/redhat/management/approval/EmailBody.java
+++ b/src/main/java/com/redhat/management/approval/EmailBody.java
@@ -48,10 +48,15 @@ public class EmailBody implements Serializable {
         values.put("contents", getRequestContentLines(requestContent));
 
         String webUrl = System.getenv("APPROVAL_WEB_URL");
-        String approveLink = webUrl + "/api/approval/v1.0/stageaction/" + approver.getRandomAccessKey();
+        // base path: /api/approval/v1.1
+        String basePath = System.getenv("APPROVAL_API_BASE_PATH");
+        // catalog base path: /ansible/catalog/approval/requests/detail/
+        String uiPath = System.getenv("APPROVAL_UI_PATH");
+
+        String approveLink = webUrl + basePath +"/stageaction/" + approver.getRandomAccessKey();
         values.put("approve_link", approveLink);
 
-        String orderLink = webUrl + "/ansible/catalog/approval/requests/detail/" + getApprovalId();
+        String orderLink = webUrl + uiPath + getApprovalId();
         values.put("order_link", orderLink);
 
         try {

--- a/src/main/java/com/redhat/management/approval/EmailBody.java
+++ b/src/main/java/com/redhat/management/approval/EmailBody.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 public class EmailBody implements Serializable {
 
     static final long serialVersionUID = 1L;
-    private static String templateFile = "EmailTemplate.html";
+    private static String templateFile = "AnsibleCatalogEmailTemplate.html";
     private static final String PARAMS_KEY = "params"; 
 
     private Approver approver;
@@ -48,16 +48,11 @@ public class EmailBody implements Serializable {
         values.put("contents", getRequestContentLines(requestContent));
 
         String webUrl = System.getenv("APPROVAL_WEB_URL");
-        // base path: /api/approval/v1.1
-        String basePath = System.getenv("APPROVAL_API_BASE_PATH");
-        // catalog base path: /ansible/catalog/approval/requests/detail/
-        String uiPath = System.getenv("APPROVAL_UI_PATH");
-
-        String approveLink = webUrl + basePath +"/stageaction/" + approver.getRandomAccessKey();
+        String approveLink = String.format("%s%s/stageaction/%s", webUrl,
+            ApprovalApiHelper.APPROVAL_API_BASE_PATH, approver.getRandomAccessKey());
         values.put("approve_link", approveLink);
-
-        String orderLink = webUrl + uiPath + getApprovalId();
-        values.put("order_link", orderLink);
+        values.put("web_url", webUrl);
+        values.put("approval_id", getApprovalId());
 
         try {
             String date = ApprovalApiHelper.formatDate("dd MMM yyyy", getCreatedTime());

--- a/src/main/resources/com/redhat/management/approval/AnsibleCatalogEmailTemplate.html
+++ b/src/main/resources/com/redhat/management/approval/AnsibleCatalogEmailTemplate.html
@@ -20,7 +20,7 @@ ${contents}
 <strong>Order Date:&nbsp;</strong>${order_date}<br>
 <strong>Order Time:&nbsp;</strong>${order_time}<br>
 <p><br></p>
-<p><strong>To VIEW this Order <a href="${order_link}">Click</a></strong>&nbsp;(requires authentication):-</p>
+<p><strong>To VIEW this Order <a href="${web_url}/ansible/catalog/approval/requests/detail/${approval_id}">Click</a></strong>&nbsp;(requires authentication)</p>
 <p><strong>To PROCESS this Order <a href="${approve_link}">Click</a></strong></p>
 <p><br></p>
 <p><strong>Order Parameters:</strong></p>


### PR DESCRIPTION
After discussion, instead of using environment variables, we put `path` information inside the email template. In the future multiple email templates may be introduce for different needs and clients.