### PR TITLE
Add cloudwatch logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,22 @@
   <packaging>kjar</packaging>
   <name>approval</name>
   <description>Management Approval Business Processes</description>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>1.11.737</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-logs</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>

--- a/src/main/java/com/redhat/management/approval/Logger.java
+++ b/src/main/java/com/redhat/management/approval/Logger.java
@@ -1,0 +1,270 @@
+package com.redhat.management.approval;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.logs.AWSLogsClient;
+import com.amazonaws.services.logs.AWSLogsClientBuilder;
+import com.amazonaws.services.logs.model.CreateLogStreamRequest;
+import com.amazonaws.services.logs.model.DescribeLogStreamsRequest;
+import com.amazonaws.services.logs.model.DescribeLogStreamsResult;
+import com.amazonaws.services.logs.model.InputLogEvent;
+import com.amazonaws.services.logs.model.InvalidSequenceTokenException;
+import com.amazonaws.services.logs.model.LogStream;
+import com.amazonaws.services.logs.model.PutLogEventsRequest;
+import com.amazonaws.services.logs.model.PutLogEventsResult;
+import com.amazonaws.services.logs.model.RejectedLogEventsInfo;
+import com.amazonaws.services.logs.model.ResourceAlreadyExistsException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Logger implements Runnable{
+  static private final String PID = getProcessId();
+  static private final Logger LOGGER = new Logger();
+  static private final long FORCE_FLUSH_INTERVAL = 1000L;
+
+  private final BlockingQueue<InputLogEvent> eventQueue = new LinkedBlockingQueue<InputLogEvent>();;
+  private final Thread writerThread;
+  private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+  private ScheduledFuture<?> futureHandle;
+  private final Runnable futureTask;
+  private final AWSLogsClient client;
+  private String nextToken;
+  private long lastFlushTime;
+  private final ThreadLocal<String> httpRequestId = new ThreadLocal<String>();
+  private final String logGroupName = System.getenv("CLOUD_WATCH_LOG_GROUP");
+  private final String logStreamName = System.getenv("HOSTNAME");
+  private final String accessKeyId = System.getenv("CW_AWS_ACCESS_KEY_ID");
+  private final String secretKey = System.getenv("CW_AWS_SECRET_ACCESS_KEY");
+  private final String awsRegion = System.getenv("CW_AWS_REGION") ;
+  private final String hostName = System.getenv("HOSTNAME");
+
+  public static Logger getLogger() {
+    return LOGGER;
+  }
+
+  public static Logger getLogger(String httpRequestId) {
+    LOGGER.setHttpRequestId(httpRequestId);
+    return LOGGER;
+  }
+
+  private Logger() {
+    client = initCloudWatchClient();
+
+    futureTask = new Runnable() {
+      public void run() {
+        Logger.getLogger().sendLogs(true);
+      }
+    };
+
+    writerThread = new Thread(this, "CloudWatch Writer");
+    writerThread.setDaemon(true);
+    writerThread.start();
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      public void run() {
+        System.out.println("Logger shutting down");
+        try {
+          scheduler.shutdown();
+        }catch(Exception e) {
+          System.out.println("Failed to terminate scheduler");
+        }
+        Logger.getLogger().sendLogs(true);
+        if (client != null) {
+          client.shutdown();
+        }
+      }
+    });
+  }
+
+  public void interrupt() {
+    writerThread.interrupt();
+  }
+
+  public void debug(String msg) {
+    log("debug", msg);
+  }
+
+  public void info(String msg) {
+    log("info", msg);
+  }
+
+  public void warn(String msg) {
+    log("warning", msg);
+  }
+
+  public void error(String msg) {
+    log("err", msg);
+  }
+
+  private void log(String level, String msg) {
+    eventQueue.add(createEvent(level, msg));
+    synchronized (eventQueue) {
+      eventQueue.notify();
+    }
+  }
+
+  private InputLogEvent createEvent(String level, String msg) {
+    Instant now = Instant.now();
+    TreeMap<String, Object> hMsg = new TreeMap<String, Object>();
+    hMsg.put("@timestamp", now.toString());
+    hMsg.put("hostname", hostName);
+    hMsg.put("pid", Logger.PID);
+    hMsg.put("tid", String.valueOf(Thread.currentThread().getId()));
+    hMsg.put("level", level);
+    hMsg.put("message", msg);
+    if (httpRequestId.get() != null) {
+      hMsg.put("request_id", httpRequestId.get());
+    }
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String json = null;
+    try {
+      json = objectMapper.writeValueAsString(hMsg);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+      json = msg;
+    }
+
+    InputLogEvent event = new InputLogEvent();
+    event.setMessage(json);
+    event.setTimestamp(now.toEpochMilli());
+
+    return event;
+  }
+
+  private static String getProcessId() {
+    RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+    String jvmName = runtimeBean.getName();
+    return jvmName.split("@")[0];
+  }
+
+  public void run() {
+    boolean nonstop = true;
+    while(nonstop) {
+      synchronized (eventQueue) {
+        try {
+          eventQueue.wait();
+        } catch(InterruptedException e) {
+          // should not matter; wait again
+        }
+      }
+
+      // reschedule by canceling the old one and creating a new one
+      if (futureHandle != null && !futureHandle.isDone()) {
+        futureHandle.cancel(false);
+      }
+      futureHandle = this.scheduler.schedule(futureTask, FORCE_FLUSH_INTERVAL, TimeUnit.MILLISECONDS);
+
+      sendLogs(false);
+    }
+  }
+
+  public synchronized void sendLogs(boolean force) {
+    long now = System.currentTimeMillis();
+
+    if(eventQueue.isEmpty()) {
+      lastFlushTime = now;
+      return;
+    }
+
+    if (!force && now - lastFlushTime < FORCE_FLUSH_INTERVAL) {
+      return;
+    }
+
+    List<InputLogEvent> logs = new ArrayList<InputLogEvent>();
+    eventQueue.drainTo(logs);
+
+    for(InputLogEvent log : logs) {
+      System.out.println(log.getMessage());
+    }
+
+    if (client != null) {
+      logToCloud(logs);
+    }
+    lastFlushTime = now;
+  }
+
+  public void setHttpRequestId(String id) {
+    httpRequestId.set(id);
+  }
+
+  private AWSLogsClient initCloudWatchClient() {
+    if (this.accessKeyId == null || this.secretKey == null || this.logGroupName == null || this.logStreamName == null) {
+      System.out.println("CloudWatch logger is disabled because configuration is incomplete.");
+      return null;
+    }
+    AWSCredentials awsCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
+
+    AWSLogsClient client = (AWSLogsClient) AWSLogsClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(awsCredentials)).withRegion(awsRegion).build();
+
+    boolean createLogStream = true;
+
+    DescribeLogStreamsRequest request = new DescribeLogStreamsRequest().withLogGroupName(logGroupName).withLogStreamNamePrefix(logStreamName);
+    try {
+      DescribeLogStreamsResult result = client.describeLogStreams(request);
+      for (LogStream stream : result.getLogStreams()) {
+        if (stream.getLogStreamName().equals(logStreamName)) {
+          nextToken = stream.getUploadSequenceToken();
+          createLogStream = false;
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      client = null;
+      createLogStream = false;
+    }
+
+    if (createLogStream) {
+      try {
+        client.createLogStream(new CreateLogStreamRequest(logGroupName, logStreamName));
+      } catch (ResourceAlreadyExistsException e) {
+        //ignore, continue
+      } catch (Exception e) {
+        e.printStackTrace();
+        client = null; //turn off CloudWatch logger
+      }
+    }
+    return client;
+  }
+
+  private void logToCloud(List<InputLogEvent> logs) {
+    PutLogEventsRequest logEventsRequest = new PutLogEventsRequest(logGroupName, logStreamName, logs);
+    logEventsRequest.setSequenceToken(nextToken);
+    try {
+      PutLogEventsResult writeResult = client.putLogEvents(logEventsRequest);
+      RejectedLogEventsInfo rejectInfo = writeResult.getRejectedLogEventsInfo();
+      if (rejectInfo != null) {
+        if(rejectInfo.getExpiredLogEventEndIndex() != null) {
+          System.out.println("CloudWatch ERROR: Some logs have expired.");
+        }
+        if(rejectInfo.getTooNewLogEventStartIndex() != null) {
+          System.out.println("CloudWatch ERROR: Some logs are too new.");
+        }
+        if(rejectInfo.getTooOldLogEventEndIndex() != null) {
+          System.out.println("CloudWatch ERROR: Some logs are too old.");
+        }
+      }
+
+      nextToken = writeResult.getNextSequenceToken();
+    } catch (InvalidSequenceTokenException e) {
+      nextToken = e.getExpectedSequenceToken();
+      logToCloud(logs);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/resources/com/redhat/management/approval/MultiStageEmails.bpmn2
+++ b/src/main/resources/com/redhat/management/approval/MultiStageEmails.bpmn2
@@ -71,16 +71,16 @@
         </bpmn2:extensionElements>
         <bpmn2:incoming>_BB980627-76A5-4C4C-86F5-E97DE57232C1</bpmn2:incoming>
         <bpmn2:outgoing>_AEA570EB-7FED-430F-9321-A50FAA89D8B8</bpmn2:outgoing>
-        <bpmn2:script><![CDATA[System.out.println("Process request now ....");
+        <bpmn2:script><![CDATA[Logger.getLogger().info("Process request now ....");
 
 // Suppose everything should retrieve from kcontext variable [request]
 RequestPacket requestPacket = InputParser.parseRequestPacket((java.util.LinkedHashMap<String, Object>) kcontext.getVariable("request_context"));
 Request request = InputParser.parseRequest((java.util.LinkedHashMap<String, Object>)kcontext.getVariable("request"), requestPacket);
 java.util.List<Group> groups = InputParser.parseGroups((java.util.ArrayList<java.util.LinkedHashMap<String, Object>>)kcontext.getVariable("groups"));
 
-System.out.println("Request packet: " + requestPacket);
-System.out.println(request);
-System.out.println("Groups: " + groups);
+Logger.getLogger().info("Request packet: " + requestPacket);
+Logger.getLogger().info(request.toString());
+Logger.getLogger().info("Groups: " + groups);
     
 kcontext.setVariable("stageUrl", ApprovalApiHelper.getRequestUrl(request));
 kcontext.setVariable("request", request); 


### PR DESCRIPTION
A simple logger class to log messages to AWS CloudWatch.

To get the logger and set the http_request_id, call `Logger.getLogger(httpRequestId)`. This is needed only for the first call in the thread. Subsequent calls can be simply `Logger.getLogger()`. The id can be also set through `logger.setHttpRequestId(id)` method.